### PR TITLE
Fix ANSI color handling and enable mdReadme execution

### DIFF
--- a/libs/lib_colors.sh
+++ b/libs/lib_colors.sh
@@ -49,22 +49,22 @@ load_dependencies() {
 # Check if stdout is a terminal
 if [[ -t 1 ]]; then
     # --- Style ---
-    c_reset='\x1b[0m'
-    c_bold='\x1b[1m'
-    c_dim='\x1b[2m'
-    c_underline='\x1b[4m'
-    c_blink='\x1b[5m'
+    c_reset=$'\x1b[0m'
+    c_bold=$'\x1b[1m'
+    c_dim=$'\x1b[2m'
+    c_underline=$'\x1b[4m'
+    c_blink=$'\x1b[5m'
 
     # --- Foreground Colors ---
-    c_fg_black='\x1b[30m'
-    c_fg_red='\x1b[31m'
-    c_fg_green='\x1b[32m'
-    c_fg_yellow='\x1b[33m'
-    c_fg_blue='\x1b[34m'
-    c_fg_magenta='\x1b[35m'
-    c_fg_cyan='\x1b[36m'
-    c_fg_white='\x1b[37m'
-    c_fg_gray='\x1b[90m'
+    c_fg_black=$'\x1b[30m'
+    c_fg_red=$'\x1b[31m'
+    c_fg_green=$'\x1b[32m'
+    c_fg_yellow=$'\x1b[33m'
+    c_fg_blue=$'\x1b[34m'
+    c_fg_magenta=$'\x1b[35m'
+    c_fg_cyan=$'\x1b[36m'
+    c_fg_white=$'\x1b[37m'
+    c_fg_gray=$'\x1b[90m'
 
     # --- Common Combinations ---
     c_red="${c_bold}${c_fg_red}"

--- a/libs/lib_command.sh
+++ b/libs/lib_command.sh
@@ -12,26 +12,45 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
 if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
 
-# --- Dependencies ---
 load_dependencies() {
     lib_require "lib_logging.sh"
+    if function_exists "register_hooks"; then
+        register_hooks --define libCommand_define_arguments --apply libCommand_apply_args
+    fi
 }
 
 # --- Globals ---
 declare -g g_run_quiet="false"
+declare -g g_dry_run="true"
 declare -g -r ON_ERR_EXIT="on_err_exit"
 declare -g -r ON_ERR_CONT="on_err_cont"
 
+# --- Argument Hooks ---
+libCommand_define_arguments() {
+    libCmd_add -t switch -f x --long exec -v "libCommand_exec" -d "false" -m once \
+        -u "Execute commands instead of performing a dry run"
+}
+
+libCommand_apply_args() {
+    if [[ "$libCommand_exec" == "true" ]]; then
+        g_dry_run="false"
+    fi
+}
+
 # --- Functions ---
 runCommand() {
-    local perform_exec=0
+    local dry_run="$g_dry_run"
     local doOnFailure="$ON_ERR_EXIT" # Default error mode
     local command_str=""
 
     while (( "$#" )); do
         case "$1" in
             --exec|-x)
-                perform_exec=1
+                dry_run="false"
+                shift
+                ;;
+            --dry-run|-n)
+                dry_run="true"
                 shift
                 ;;
             "$ON_ERR_EXIT"|"$ON_ERR_CONT")
@@ -50,7 +69,7 @@ runCommand() {
         return 1
     fi
 
-    if [[ "$perform_exec" -eq 1 ]]; then
+    if [[ "$dry_run" == "false" ]]; then
         if [[ "$g_run_quiet" != "true" ]]; then
             log_banner "Executing: ${command_str}"
         fi

--- a/libs/lib_logging.sh
+++ b/libs/lib_logging.sh
@@ -93,7 +93,6 @@ libLogging_define_arguments() {
 # ------------------------------------------------------------------------------
 libLogging_apply_args() {
     echo "Logging: libLogging_apply_args: SetLogLevel $LogLevelStr"
-    Stack_prettyPrint --max 10
     SetLogLevel "$LogLevelStr"
 }
 

--- a/libs/lib_main.sh
+++ b/libs/lib_main.sh
@@ -150,6 +150,10 @@ initializeScript() {
 if function_exists "load_dependencies"; then
     load_dependencies
 fi
-if function_exists "initializeScript"; then
-    initializeScript "$@"
-fi
+#
+# The main library should not automatically invoke `initializeScript` when it is
+# sourced.  Scripts that use this library will explicitly call
+# `initializeScript` after defining their own arguments and logic.
+# Removing the automatic invocation avoids confusing double initialization and
+# unexpected stack traces during startup.
+#

--- a/mdReadme.sh
+++ b/mdReadme.sh
@@ -53,11 +53,11 @@ define_arguments() {
 # ------------------------------------------------------------------------------
 select_parser() {
     local parser=""
-    if [ "$use_glow" ] ;  then
+    if [[ "$glow" == "true" ]]; then
         parser="glow"
-    elif [ "$use_mdcat" ] ; then
+    elif [[ "$use_mdcat" == "true" ]]; then
         parser="mdcat"
-    elif [ "$use_rich" ] ; then
+    elif [[ "$use_rich" == "true" ]]; then
         parser="rich"
     else
         parser="$def_parser"
@@ -86,9 +86,9 @@ main() {
     parser="$(select_parser)"
         
     # 3. Orchestrate the core logic, using the globally-set $g_execution_flag.
-    log --debug "$hande_parser $p_args"
+    log --debug "$parser $p_args"
 
-    runCommand "$hande_parser $p_args"
+    runCommand "$parser $p_args"
 
     log --debug "✅ Script finished."
 }
@@ -97,5 +97,5 @@ main() {
 # Main Execution Guard
 # ==============================================================================
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    main "$@" "--exec"
+    main "$@"
 fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -13,16 +13,14 @@ source "$SCRIPT_DIR/../libs/lib_main.sh"
 # ==============================================================================
 
 define_arguments() {
-    lib_logging_initialize
     libCmd_add -t switch -f h --long help -v "showHelp" -d "false" -m once -u "Display this help message."
     libCmd_add -t value  -f t --long test -v "tests_to_run" -m multi -u "Optional: Specify a test to run. Defaults to all."
 }
 
 main() {
-    if ! lib_initializeScript "$@"; then
+    if ! initializeScript "$@"; then
         return 1
     fi
-    set_log_level
 
     local test_dir="${SCRIPT_DIR}"
     if [[ ! -d "$test_dir" ]]; then


### PR DESCRIPTION
## Summary
- ensure ANSI color escape sequences render correctly
- execute selected parser in `mdReadme.sh` and clean startup
- remove stack traces and auto-initialize behavior from libraries
- add global dry-run flag to `lib_command.sh` and rely on it in `mdReadme.sh`

## Testing
- `./mdReadme.sh README.md`
- `./mdReadme.sh --exec README.md` *(fails: glow: command not found)*
- `./tests/run_tests.sh` *(fails: dependency 'libs/lib_fs.sh' missing)*

------
https://chatgpt.com/codex/tasks/task_e_689be5d5ffa48331ae07026874e5a590