### PR TITLE
Refactor boolean handling via lib_bool

### DIFF
--- a/gpush.sh
+++ b/gpush.sh
@@ -40,13 +40,13 @@ lib_require "lib_bool.sh"
 
 define_arguments() {
     # Core script options
-    libCmd_add -t switch -f n --long dry-run  -v "gp_dry_run"   -d "false" -m once -u "Show actions without running them"
-    libCmd_add -t switch      --long no-add   -v "gp_no_add"    -d "false" -m once -u "Skip 'git add .'"
-    libCmd_add -t switch      --long amend    -v "gp_amend"     -d "false" -m once -u "Amend last commit with staged changes and message"
-    libCmd_add -t switch -f s --long signoff  -v "gp_signoff"   -d "false" -m once -u "Add Signed-off-by trailer"
-    libCmd_add -t switch -f t --long tags     -v "gp_push_tags" -d "false" -m once -u "Also push tags"
+    libCmd_add -t switch -f n --long dry-run  -v "gp_dry_run"   -d "$FALSE" -m once -u "Show actions without running them"
+    libCmd_add -t switch      --long no-add   -v "gp_no_add"    -d "$FALSE" -m once -u "Skip 'git add .'"
+    libCmd_add -t switch      --long amend    -v "gp_amend"     -d "$FALSE" -m once -u "Amend last commit with staged changes and message"
+    libCmd_add -t switch -f s --long signoff  -v "gp_signoff"   -d "$FALSE" -m once -u "Add Signed-off-by trailer"
+    libCmd_add -t switch -f t --long tags     -v "gp_push_tags" -d "$FALSE" -m once -u "Also push tags"
     libCmd_add -t value -f m  --long message  -v "gp_message"   -d "."     -m once -u "Commit message (default '.')"
-    libCmd_add -t switch -f q --long quiet    -v "gp_quiet"     -d "false" -m once -u "Suppress run banners"
+    libCmd_add -t switch -f q --long quiet    -v "gp_quiet"     -d "$FALSE" -m once -u "Suppress run banners"
 }
 
 # --- Implementation -----------------------------------------------------------
@@ -89,14 +89,13 @@ _gpush_main() {
     log_entry
 
     # Convert lib_cmdArgs string booleans to canonical 0/1 for logic.
-    bool_set GP_DRY_RUN   "${gp_dry_run:-false}"
-    bool_set GP_NO_ADD    "${gp_no_add:-false}"
-    bool_set GP_AMEND     "${gp_amend:-false}"
-    bool_set GP_SIGNOFF   "${gp_signoff:-false}"
-    bool_set GP_PUSH_TAGS "${gp_push_tags:-false}"
+    bool_set GP_DRY_RUN   "${gp_dry_run:-$FALSE}"
+    bool_set GP_NO_ADD    "${gp_no_add:-$FALSE}"
+    bool_set GP_AMEND     "${gp_amend:-$FALSE}"
+    bool_set GP_SIGNOFF   "${gp_signoff:-$FALSE}"
+    bool_set GP_PUSH_TAGS "${gp_push_tags:-$FALSE}"
 
-    # Quiet banners if requested (lib_command checks this string var)
-    if [[ "${gp_quiet:-false}" == "true" ]]; then g_run_quiet="true"; fi
+    bool_set g_run_quiet  "${gp_quiet:-$FALSE}"
 
     # Determine commit message precedence: --message beats positional; default "."
     local comment="$gp_message"

--- a/libs/lib_bool.sh
+++ b/libs/lib_bool.sh
@@ -20,8 +20,12 @@
 # ---- Canonical constants -----------------------------------------------------
 # Note: not exported by default. Export if children need them:
 #   export TRUE FALSE
-declare -ri TRUE=1
-declare -ri FALSE=0
+if ! declare -p TRUE &>/dev/null; then
+  declare -ri TRUE=1
+fi
+if ! declare -p FALSE &>/dev/null; then
+  declare -ri FALSE=0
+fi
 
 
 # ---- API ---------------------------------------------------------------------

--- a/libs/lib_cmdArgs.sh
+++ b/libs/lib_cmdArgs.sh
@@ -17,8 +17,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # ------------------------------------------------------------------------------
 # FUNCTION: load_dependencies
@@ -65,7 +70,7 @@ libCmdArgs_define_arguments() {
 libCmdArgs_apply_args() {
     log_entry
     log --Debug "ShowHelp = $ShowHelp"
-    if [[ "$ShowHelp" == "true" ]] ; then 
+    if (( ShowHelp )) ; then
         libCmd_usage
     fi
     log_exit
@@ -176,7 +181,7 @@ libCmd_parse() {
         IFS="$_CMD_ARGS_DELIMITER" read -r argType varName _ _ multiplicity _ _ <<< "$arg_spec"
         local value=""
         if [[ "$argType" == "switch" ]]; then
-            value="true"; shift
+            value=$TRUE; shift
         else
             if [[ -n "$value_from_equals" ]]; then
                 value="$value_from_equals"; shift

--- a/libs/lib_colors.sh
+++ b/libs/lib_colors.sh
@@ -11,8 +11,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 load_dependencies() { 
@@ -87,7 +92,7 @@ fi
 #   Defines the command-line arguments related to color output.
 # ------------------------------------------------------------------------------
 libColors_define_arguments() {
-    libCmd_add -t switch -f n --long no-color -v "g_no_color" -d "false" -m once -u "Disable all color output."
+    libCmd_add -t switch -f n --long no-color -v "g_no_color" -d "$FALSE" -m once -u "Disable all color output."
 }
 
 # ------------------------------------------------------------------------------
@@ -97,7 +102,7 @@ libColors_define_arguments() {
 #   Applies the logic for color-related arguments after parsing.
 # ------------------------------------------------------------------------------
 libColors_apply_args() {
-    if [[ "${g_no_color:-false}" == "true" ]]; then
+    if (( g_no_color )); then
         disable_colors
     fi
 }

--- a/libs/lib_core.sh
+++ b/libs/lib_core.sh
@@ -6,9 +6,15 @@
 #********************************************
 # Sourcing Guard
 #********************************************
+source "$(dirname "${BASH_SOURCE[0]}")/lib_bool.sh"
 filename="$(basename "${BASH_SOURCE[0]}")"
 isSourcedName="sourced_${filename//[^a-zA-Z0-9_]/_}"
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 #********************************************
 # Global variable for the library path

--- a/libs/lib_format.sh
+++ b/libs/lib_format.sh
@@ -8,8 +8,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 load_dependencies() {

--- a/libs/lib_grep.sh
+++ b/libs/lib_grep.sh
@@ -8,8 +8,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 load_dependencies() {

--- a/libs/lib_logging.sh
+++ b/libs/lib_logging.sh
@@ -14,8 +14,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 load_dependencies() {
@@ -51,7 +56,7 @@ readonly LogLvl_All=64 # Sum of all levels above
 LoggingLevel=${LogLvl_Info} # Default numeric level
 LogLevelStr="INFO"         # Default string for the command-line arg
 LogFile=""
-LogShowColor=true
+LogShowColor=$TRUE
 
 # Colors are initially nothing because lib_colors has not been initialized  yet
 c_error=""
@@ -210,27 +215,27 @@ log() {
     fi
     level=$(ToLogLvl_FromString "$1")
     shift
-    local msg_only=false
-    local always=false
+    local msg_only=$FALSE
+    local always=$FALSE
 
     # Parse flags
     while true; do
         case "$1" in
-            -MsgOnly) msg_only=true; shift;;
-            -Always)  always=true;   shift;;
+            -MsgOnly) msg_only=$TRUE; shift;;
+            -Always)  always=$TRUE;   shift;;
             *) break;;
         esac
     done
 
     # Check if the message should be logged
-    # if [[ "$always" == true ]] || (( (LogLevel & msgLogLevel) != 0 )); then
-    if [[ "$always" == true ]] || (( $level <= $LoggingLevel )); then
+    # if (( always )) || (( (LogLevel & msgLogLevel) != 0 )); then
+    if (( always )) || (( level <= LoggingLevel )); then
         local msg="$*"
         local out_str=""
         local file_out_str=""
 
         # Only show metadata for non-MsgOnly and non-Instr
-        if [[ "$msg_only" == true ]] || [[ "$level" == "$LogLvl_Instr" ]]; then
+        if (( msg_only )) || [[ "$level" == "$LogLvl_Instr" ]]; then
             out_str="$msg"
             file_out_str="$msg"
         else
@@ -241,7 +246,7 @@ log() {
         fi
 
         # Add color for console output if enabled
-        if [[ "$LogShowColor" == true ]]; then
+        if (( LogShowColor )); then
             local color
             if   [[ "$level" == "$LogLvl_Error" ]]; then     color="$c_error"
             elif [[ "$level" == "$LogLvl_Warn"  ]]; then     color="$c_warn"

--- a/libs/lib_main.sh
+++ b/libs/lib_main.sh
@@ -18,8 +18,13 @@ source "$g_lib_dir/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 load_dependencies() {

--- a/libs/lib_mathUtils.sh
+++ b/libs/lib_mathUtils.sh
@@ -11,8 +11,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # ==============================================================================
 # FUNCTIONS

--- a/libs/lib_stackTrace.sh
+++ b/libs/lib_stackTrace.sh
@@ -16,8 +16,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 load_dependencies() {
@@ -158,14 +163,14 @@ Stack_get() {
 #   --no-color (switch, optional): Disables colored output.
 # ------------------------------------------------------------------------------
 Stack_prettyPrint() {
-    local use_color=true
+    local use_color=$TRUE
     # Skip this prettyPrint function itself by default.
     local skip=1
     local max=-1
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --no-color) use_color=false; shift ;;
+            --no-color) use_color=$FALSE; shift ;;
             --skip) skip=$2; shift 2 ;;
             --max) max=$2; shift 2 ;;
             *) shift ;;
@@ -200,7 +205,7 @@ Stack_prettyPrint() {
     header_func=$(PadText "Function" "$max_func" "center")
     header_line=$(PadText "Line" "$max_line" "center")
 
-    if $use_color; then
+    if (( use_color )); then
         printf "%s%s  %s  %s%s\n" "${c_bold}${c_cyan}" "$header_file" "$header_func" "$header_line" "${c_reset}"
     else
         printf "%s  %s  %s\n" "$header_file" "$header_func" "$header_line"
@@ -215,7 +220,7 @@ Stack_prettyPrint() {
         p_func=$(PadText "$func" "$max_func" "left" " ")
         p_line=$(PadText "$line" "$max_line" "right" " ")
 
-        if $use_color; then
+        if (( use_color )); then
             printf "%s%s%s  %s%s%s  %s%s%s\n" "${c_yellow}" "$p_file" "${c_reset}" "${c_green}" "$p_func" "${c_reset}" "${c_cyan}" "$p_line" "${c_reset}"
         else
             printf "%s  %s  %s\n" "$p_file" "$p_func" "$p_line"

--- a/libs/lib_sysInfoUtils.sh
+++ b/libs/lib_sysInfoUtils.sh
@@ -11,8 +11,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib_core.sh"
 
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
-isSourcedName="$(sourced_name ${BASH_SOURCE[0]})" 
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+isSourcedName="$(sourced_name ${BASH_SOURCE[0]})"
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 

--- a/libs/lib_thisFile.sh
+++ b/libs/lib_thisFile.sh
@@ -6,9 +6,15 @@
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
 # Not using lib_core.sh so as to not cause a dependency
+source "$(dirname "${BASH_SOURCE[0]}")/lib_bool.sh"
 filename="$(basename "${BASH_SOURCE[0]}")"
 isSourcedName="sourced_${filename//[^a-zA-Z0-9_]/_}"
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Introspection Functions ---
 # ------------------------------------------------------------------------------

--- a/libs/lib_types.sh
+++ b/libs/lib_types.sh
@@ -9,9 +9,15 @@
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
 # Not using lib_core.sh so as to not cause a dependency
+source "$(dirname "${BASH_SOURCE[0]}")/lib_bool.sh"
 filename="$(basename "${BASH_SOURCE[0]}")"
 isSourcedName="sourced_${filename//[^a-zA-Z0-9_]/_}"
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 

--- a/libs/lib_utils.sh
+++ b/libs/lib_utils.sh
@@ -6,9 +6,15 @@
 # Sourcing Guard
 # Create a sanitized, unique variable name from the filename.
 # Not using lib_core.sh so as to not cause a dependency
+source "$(dirname "${BASH_SOURCE[0]}")/lib_bool.sh"
 filename="$(basename "${BASH_SOURCE[0]}")"
 isSourcedName="sourced_${filename//[^a-zA-Z0-9_]/_}"
-if declare -p "$isSourcedName" > /dev/null 2>&1; then return 0; else declare -g "$isSourcedName=true"; fi
+if declare -p "$isSourcedName" > /dev/null 2>&1; then
+    return 0
+else
+    declare -g "$isSourcedName"
+    bool_set "$isSourcedName" 1
+fi
 
 # --- Dependencies ---
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -13,7 +13,7 @@ source "$SCRIPT_DIR/../libs/lib_main.sh"
 # ==============================================================================
 
 define_arguments() {
-    libCmd_add -t switch -f h --long help -v "showHelp" -d "false" -m once -u "Display this help message."
+    libCmd_add -t switch -f h --long help -v "showHelp" -d "$FALSE" -m once -u "Display this help message."
     libCmd_add -t value  -f t --long test -v "tests_to_run" -m multi -u "Optional: Specify a test to run. Defaults to all."
 }
 

--- a/tests/test_cmdArgs.sh
+++ b/tests/test_cmdArgs.sh
@@ -11,7 +11,7 @@ run_suite() {
     # Define a local function for this test scope
     define_test_args() {
         libCmd_add -t value  --long input-file -f i -v "inputFile" -r y -u "Input file"
-        libCmd_add -t switch --long verbose    -f v -v "verboseMode" -d "false" -u "Enable verbose mode"
+        libCmd_add -t switch --long verbose    -f v -v "verboseMode" -d "$FALSE" -u "Enable verbose mode"
         libCmd_add -t value  --long packages   -f p -v "pkg_list" -m multi -u "Packages to install"
     }
 
@@ -21,21 +21,21 @@ run_suite() {
     define_test_args
     libCmd_parse --input-file "my.txt" -v --packages "vim" -p "git"
 
-    local test_failed=false
+    local test_failed=$FALSE
     if [[ "$inputFile" != "my.txt" ]]; then
         log --error "FAIL: inputFile was not set correctly. Expected 'my.txt', got '$inputFile'."
-        test_failed=true
+        test_failed=$TRUE
     fi
-    if [[ "$verboseMode" != "true" ]]; then
+    if (( ! verboseMode )); then
         log --error "FAIL: verboseMode switch was not set correctly."
-        test_failed=true
+        test_failed=$TRUE
     fi
     if [[ "${#pkg_list[@]}" -ne 2 ]] || [[ "${pkg_list[0]}" != "vim" ]] || [[ "${pkg_list[1]}" != "git" ]]; then
         log --error "FAIL: pkg_list multi-argument was not set correctly."
-        test_failed=true
+        test_failed=$TRUE
     fi
 
-    if [[ "$test_failed" == false ]]; then
+    if (( ! test_failed )); then
         log --test "PASS: libCmd_parse correctly set all variable types."
     else
         overall_status=1

--- a/tests/test_logging.sh
+++ b/tests/test_logging.sh
@@ -28,7 +28,7 @@ run_suite() {
         log --warn "Warn Message"
         log --error "Error Message"
 
-        local test_failed_for_this_level=false
+        local test_failed_for_this_level=$FALSE
         # Verification logic remains the same...
         for level_to_verify in "${!LOG_LEVELS[@]}"; do
             if [[ "$level_to_verify" == "none" ]]; then continue; fi
@@ -37,21 +37,21 @@ run_suite() {
                 should_be_present=1
             fi
 
-            local was_seen=false
+            local was_seen=$FALSE
             if grep -q "\[${level_to_verify^^}\]" "$test_log_file"; then
-                was_seen=true
+                was_seen=$TRUE
             fi
 
-            if (( should_be_present == 1 )) && [[ "$was_seen" == false ]]; then
+            if (( should_be_present == 1 )) && (( ! was_seen )); then
                 log --error "FAIL: Expected to find '[${level_to_verify^^}]' in log, but it was absent."
-                test_failed_for_this_level=true
-            elif (( should_be_present == 0 )) && [[ "$was_seen" == true ]]; then
+                test_failed_for_this_level=$TRUE
+            elif (( should_be_present == 0 )) && (( was_seen )); then
                 log --error "FAIL: Did NOT expect to find '[${level_to_verify^^}]' in log, but it was present."
-                test_failed_for_this_level=true
+                test_failed_for_this_level=$TRUE
             fi
         done
 
-        if [[ "$test_failed_for_this_level" == false ]]; then
+        if (( ! test_failed_for_this_level )); then
             log_always "PASS: Log level '$level_to_set' filtered messages correctly."
         else
             overall_status=1


### PR DESCRIPTION
## Summary
- Load lib_bool in core and utilities to supply canonical TRUE/FALSE
- Replace string-based boolean checks with arithmetic ones across libs and scripts
- Guard lib_bool constants to allow repeat sourcing

## Testing
- `./run_tests.sh --test test_command --test test_logging --test test_cmdArgs` (fails: `log_always: command not found` and missing test dependencies)

------
https://chatgpt.com/codex/tasks/task_e_689c4fcc7ea4833189beb0d61ee3c31b